### PR TITLE
 New Tool: OMERO region of interest (ROI) upload using ezomero

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,7 +43,7 @@ jobs:
       commit-range: ${{ steps.discover.outputs.commit-range }}
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     steps:
     - name: Print github context properties
       run: |
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -257,7 +257,7 @@ jobs:
       fail-fast: false
       matrix:
         chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     services:
       postgres:
         image: postgres:11
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.9']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,7 +43,7 @@ jobs:
       commit-range: ${{ steps.discover.outputs.commit-range }}
     strategy:
       matrix:
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     steps:
     - name: Print github context properties
       run: |
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -257,7 +257,7 @@ jobs:
       fail-fast: false
       matrix:
         chunk: ${{ fromJson(needs.setup.outputs.chunk-list) }}
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     services:
       postgres:
         image: postgres:11
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11.9']
+        python-version: ['3.10']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/tools/omero/.shed.yml
+++ b/tools/omero/.shed.yml
@@ -1,8 +1,8 @@
 categories:
 - Imaging
 name: omero_upload
-description: Import images and metadata into an OMERO.server using omero-py
-long_description: Tool to import images into a target dataset in OMERO
+description: Import images, region of interest, metadata into an OMERO.server using omero-py
+long_description: Tool to import and link different objects into OMERO
 owner: ufz
 remote_repository_url: https://github.com/Helmholtz-UFZ/galaxy-tools/tree/main/tools/omero
 homepage_url: https://github.com/ome/omero-py/

--- a/tools/omero/omero_import.xml
+++ b/tools/omero/omero_import.xml
@@ -25,8 +25,8 @@
         omero import folder -T Dataset:name:$dataset_name
             -s $omero_host
             -p $omero_port
-            -u $__user__.extra_preferences.get('omero|username', $test_username)
-            -w $__user__.extra_preferences.get('omero|password', $test_password)
+            -u $__user__.extra_preferences.get('omero_account|username', $test_username)
+            -w $__user__.extra_preferences.get('omero_account|password', $test_password)
         > $log &&
 
         omero logout

--- a/tools/omero/omero_import.xml
+++ b/tools/omero/omero_import.xml
@@ -2,7 +2,7 @@
     <description> with omero-py </description>
     <macros>
         <token name="@TOOL_VERSION@">5.18.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">omero</xref>
@@ -36,6 +36,7 @@
         <param name="dataset_name" type="text" optional="false" label="Target Dataset Name"/>
         <param name="omero_host" type="text" label="OMERO host URL">
             <validator type="regex" message="Enter a valid host location, for example, your.omero.server">^[a-zA-Z0-9._-]*$</validator>
+            <validator type="expression" message="No two dots (..) allowed">'..' not in value</validator>
         </param>
         <param name="omero_port" type="integer" value="4064" optional="false" label="OMERO port"/>
         <param name="test_username" type="hidden" value=""/>

--- a/tools/omero/omero_metadata_import.xml
+++ b/tools/omero/omero_metadata_import.xml
@@ -15,8 +15,8 @@
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
         python $__tool_directory__/omero_metadata_upload.py
-        --user $__user__.extra_preferences.get('omero|username', $test_username)
-        --pws $__user__.extra_preferences.get('omero|password', $test_password)
+        --user $__user__.extra_preferences.get('omero_account|username', $test_username)
+        --pws $__user__.extra_preferences.get('omero_account|username', $test_password)
         --host $omero_host
         --port $omero_port
         --obj_type $obj_type

--- a/tools/omero/omero_metadata_import.xml
+++ b/tools/omero/omero_metadata_import.xml
@@ -3,7 +3,7 @@
     <description> with ezomero </description>
     <macros>
         <token name="@TOOL_VERSION@">5.18.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">omero</xref>
@@ -11,6 +11,7 @@
     <requirements>
         <requirement type="package" version="3.0.1">ezomero</requirement>
         <requirement type="package" version="2.2.2">pandas</requirement>
+        <!-- openjdk is needed: https://github.com/conda-forge/omero-py-feedstock/pull/16 -->
         <requirement type="package" version="21.0.2">openjdk</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
@@ -29,7 +30,10 @@
         #end if
     ]]></command>
     <inputs>
-        <param argument="omero_host" type="text" optional="false" label="OMERO host URL"/>
+        <param name="omero_host" type="text" label="OMERO host URL">
+            <validator type="regex" message="Enter a valid host location, for example, your.omero.server">^[a-zA-Z0-9._-]*$</validator>
+            <validator type="expression" message="No two dots (..) allowed">'..' not in value</validator>
+        </param>
         <param argument="omero_port" type="integer" optional="false" value="4064" label="OMERO port"/>
         <param argument="obj_type" type="select" optional="true" label="Target Object Type">
             <option value="project">Project</option>

--- a/tools/omero/omero_roi_import.xml
+++ b/tools/omero/omero_roi_import.xml
@@ -1,0 +1,105 @@
+<tool id="omero_roi_import" name="OMERO ROI Import" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@"
+      profile="20.01" license="MIT">
+    <description> with ezomero </description>
+    <macros>
+        <token name="@TOOL_VERSION@">5.18.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+    </macros>
+    <xrefs>
+        <xref type="bio.tools">omero</xref>
+    </xrefs>
+    <requirements>
+        <requirement type="package" version="3.0.1">ezomero</requirement>
+        <requirement type="package" version="2.2.2">pandas</requirement>
+        <requirement type="package" version="21.0.2">openjdk</requirement>
+    </requirements>
+    <command detect_errors="exit_code"><![CDATA[
+        python $__tool_directory__/omero_roi_upload.py
+        --input_file $input
+        --image_id $id
+        --user $__user__.extra_preferences.get('omero|username', $test_username)
+        --psw $__user__.extra_preferences.get('omero|password', $test_password)
+        --host $omero_host
+        --port $omero_port
+        --log_file $log
+    ]]></command>
+    <inputs>
+        <param argument="input" type="data" format="tabular" optional="false" label="Tab File with ROIs" help="Select ROIs Tabular file"/>
+        <param argument="id" type="integer" optional="false" label="Image ID where annotate the ROIs"/>
+        <param argument="omero_host" type="text" optional="false" label="OMERO host URL"/>
+        <param argument="omero_port" type="integer" optional="false" value="4064" label="OMERO port"/>
+        <param name="test_username" type="hidden" value=""/>
+        <param name="test_password" type="hidden" value=""/>
+    </inputs>
+    <outputs>
+        <data name="log" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="omero_host" value="localhost"/>
+            <param name="omero_port" value="4064"/>
+            <param name="id" value="1"/>
+            <param name="input" value="/home/massei/Documents/01_Projects/09_NFDI4BIOIMAGE/08_OMERO_UFZ_Python/mb-galaxy-tools/tools/omero/test-data/input_roi.tsv"/>
+            <param name="test_username" value="root"/>
+            <param name="test_password" value="omero"/>
+            <output name="log" value="output_table_roi.txt" ftype="txt">
+                <assert_contents>
+                    <has_text text="ROI ID: 7 for row 7"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+
+Description
+-----------
+
+Tool to upload Regions of Interest (ROIs) to an OMERO server based on shape data provided
+in a tabular format (TSV file). The tool reads the shape information from the TSV file, creates the
+corresponding ROIs in OMERO, and links them to a specified image.
+
+**Column Headers**:
+
+        - shape, x, y, x_rad, y_rad, width, height, label, fontSize, x1, y1, x2, y2, points, fill_color, stroke_color, stroke_width, z, c, t, roi_name, roi_description
+
+- *Shape Type*:
+
+    The **shape** column indicates the type of shape being defined, such as Ellipse, Label, Line, Point, Polygon, Polyline, or Rectangle.
+
+- *Position and Dimensions*:
+
+    The columns **x**, **y**, **x_rad**, **y_rad**, **width**, and **height** specify the position and dimensions of the shapes, where applicable. For example, Ellipse uses x, y, x_rad, and y_rad, while Rectangle uses x, y, width, and height.
+
+- *Text Labels*:
+
+    The **label** and **fontSize** columns are used for the Label shape, specifying the text content and font size.
+
+- *Line Coordinates*:
+
+    The columns **x1**, **y1**, **x2**, and **y2** are used for defining the start and end points of a Line.
+
+- *Point Coordinates*:
+
+    The **points** column is used for defining multiple points in shapes like Polygon and Polyline. The points are listed as coordinate pairs.
+
+- *Colors*:
+
+    The **fill_color** and **stroke_color** columns define the fill and stroke colors of the shapes in RGBA format.
+
+- *Stroke Width*:
+
+    The **stroke_width** column specifies the width of the stroke or border around the shapes.
+
+- *Z, C, T Coordinates*:
+
+    The **z**, **c**, and **t** columns indicate the Z-plane, channel, and time point to which the shape is associated in the image stack.
+
+- *ROI Identification*:
+
+    The **roi_name** and **roi_description** columns provide a name and description for each ROI, allowing for easy identification and documentation within OMERO.
+
+    </help>
+    <citations>
+        <citation type="doi">10.1038/nmeth.1896</citation>
+    </citations>
+</tool>

--- a/tools/omero/omero_roi_import.xml
+++ b/tools/omero/omero_roi_import.xml
@@ -36,10 +36,10 @@
     </outputs>
     <tests>
         <test>
-            <param name="omero_host" value="localhost"/>
-            <param name="omero_port" value="4064"/>
+            <param name="omero_host" value="host.docker.internal"/>
+            <param name="omero_port" value="6064"/>
             <param name="id" value="1"/>
-            <param name="input" value="/home/massei/Documents/01_Projects/09_NFDI4BIOIMAGE/08_OMERO_UFZ_Python/mb-galaxy-tools/tools/omero/test-data/input_roi.tsv"/>
+            <param name="input" value="input_roi.tsv"/>
             <param name="test_username" value="root"/>
             <param name="test_password" value="omero"/>
             <output name="log" value="output_table_roi.txt" ftype="txt">

--- a/tools/omero/omero_roi_import.xml
+++ b/tools/omero/omero_roi_import.xml
@@ -17,8 +17,8 @@
         python $__tool_directory__/omero_roi_upload.py
         --input_file $input
         --image_id $id
-        --user $__user__.extra_preferences.get('omero|username', $test_username)
-        --psw $__user__.extra_preferences.get('omero|password', $test_password)
+        --user $__user__.extra_preferences.get('omero_account|username', $test_username)
+        --psw $__user__.extra_preferences.get('omero_account|password', $test_password)
         --host $omero_host
         --port $omero_port
         --log_file $log

--- a/tools/omero/omero_roi_import.xml
+++ b/tools/omero/omero_roi_import.xml
@@ -3,7 +3,7 @@
     <description> with ezomero </description>
     <macros>
         <token name="@TOOL_VERSION@">5.18.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">omero</xref>
@@ -11,22 +11,26 @@
     <requirements>
         <requirement type="package" version="3.0.1">ezomero</requirement>
         <requirement type="package" version="2.2.2">pandas</requirement>
+        <!-- openjdk is needed: https://github.com/conda-forge/omero-py-feedstock/pull/16 -->
         <requirement type="package" version="21.0.2">openjdk</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        python $__tool_directory__/omero_roi_upload.py
-        --input_file $input
-        --image_id $id
-        --user $__user__.extra_preferences.get('omero_account|username', $test_username)
-        --psw $__user__.extra_preferences.get('omero_account|password', $test_password)
-        --host $omero_host
-        --port $omero_port
-        --log_file $log
+        python '$__tool_directory__/omero_roi_upload.py'  
+        --input_file '$input'  
+        --image_id $id  
+        --user '$__user__.extra_preferences.get("omero_account|username", $test_username)'  
+        --psw '$__user__.extra_preferences.get("omero_account|password", $test_password)'  
+        --host '$omero_host'  
+        --port $omero_port  
+        --log_file '$log'  
     ]]></command>
     <inputs>
         <param argument="input" type="data" format="tabular" optional="false" label="Tab File with ROIs" help="Select ROIs Tabular file"/>
         <param argument="id" type="integer" optional="false" label="Image ID where annotate the ROIs"/>
-        <param argument="omero_host" type="text" optional="false" label="OMERO host URL"/>
+        <param name="omero_host" type="text" label="OMERO host URL">
+            <validator type="regex" message="Enter a valid host location, for example, your.omero.server">^[a-zA-Z0-9._-]*$</validator>
+            <validator type="expression" message="No two dots (..) allowed">'..' not in value</validator>
+        </param>
         <param argument="omero_port" type="integer" optional="false" value="4064" label="OMERO port"/>
         <param name="test_username" type="hidden" value=""/>
         <param name="test_password" type="hidden" value=""/>

--- a/tools/omero/omero_roi_upload.py
+++ b/tools/omero/omero_roi_upload.py
@@ -2,7 +2,7 @@ import argparse
 import re
 
 import pandas as pd
-from ezomero import connect,post_roi
+from ezomero import connect, post_roi
 from ezomero.rois import Ellipse, Label, Line, Point, Polygon, Polyline, Rectangle
 
 

--- a/tools/omero/omero_roi_upload.py
+++ b/tools/omero/omero_roi_upload.py
@@ -5,10 +5,12 @@ from ezomero import post_roi, connect
 from ezomero.rois import Ellipse, Label, Line, Point, Polygon, Polyline, Rectangle
 import pandas as pd
 
+
 def parse_color(color_str):
     if not color_str:
         return None
     return tuple(map(int, re.findall(r'\d+', color_str)))
+
 
 def parse_points(points_str):
     if not points_str:
@@ -18,6 +20,7 @@ def parse_points(points_str):
     points = points_str.split("),(")
     points = [point.strip("()") for point in points]  # Remove any remaining parentheses
     return [tuple(map(float, point.split(','))) for point in points]
+
 
 def create_shape(row):
     shape_type = row['shape']
@@ -111,6 +114,7 @@ def create_shape(row):
         )
     return shape
 
+
 def main(input_file, conn, image_id, log_file):
     # Open log file
     with open(log_file, 'w') as log:
@@ -131,6 +135,7 @@ def main(input_file, conn, image_id, log_file):
                 msg = f"Skipping row {index + 1}: Unable to create shape"
                 print(msg)
                 log.write(msg + "\n")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/tools/omero/omero_roi_upload.py
+++ b/tools/omero/omero_roi_upload.py
@@ -1,9 +1,9 @@
 import argparse
 import re
 
-from ezomero import post_roi, connect
-from ezomero.rois import Ellipse, Label, Line, Point, Polygon, Polyline, Rectangle
 import pandas as pd
+from ezomero import connect,post_roi
+from ezomero.rois import Ellipse, Label, Line, Point, Polygon, Polyline, Rectangle
 
 
 def parse_color(color_str):

--- a/tools/omero/omero_roi_upload.py
+++ b/tools/omero/omero_roi_upload.py
@@ -1,0 +1,160 @@
+import argparse
+import re
+
+from ezomero import post_roi, connect
+from ezomero.rois import Ellipse, Label, Line, Point, Polygon, Polyline, Rectangle
+import pandas as pd
+
+def parse_color(color_str):
+    if not color_str:
+        return None
+    return tuple(map(int, re.findall(r'\d+', color_str)))
+
+def parse_points(points_str):
+    if not points_str:
+        return None
+    # Remove leading and trailing brackets and split into individual points
+    points_str = points_str.strip("[]")
+    points = points_str.split("),(")
+    points = [point.strip("()") for point in points]  # Remove any remaining parentheses
+    return [tuple(map(float, point.split(','))) for point in points]
+
+def create_shape(row):
+    shape_type = row['shape']
+    shape = None
+
+    if shape_type == 'Ellipse':
+        shape = Ellipse(
+            x=row['x'],
+            y=row['y'],
+            x_rad=row['x_rad'],
+            y_rad=row['y_rad'],
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Label':
+        shape = Label(
+            x=row['x'],
+            y=row['y'],
+            label=row['label'],
+            fontSize=row['fontSize'],
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Line':
+        shape = Line(
+            x1=row['x1'],
+            y1=row['y1'],
+            x2=row['x2'],
+            y2=row['y2'],
+            markerStart=row.get('markerStart', None),
+            markerEnd=row.get('markerEnd', None),
+            label=row.get('label', None),
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Point':
+        shape = Point(
+            x=row['x'],
+            y=row['y'],
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Polygon':
+        shape = Polygon(
+            points=parse_points(row['points']),
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Polyline':
+        shape = Polyline(
+            points=parse_points(row['points']),
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    elif shape_type == 'Rectangle':
+        shape = Rectangle(
+            x=row['x'],
+            y=row['y'],
+            width=row['width'],
+            height=row['height'],
+            z=row.get('z'),
+            c=row.get('c'),
+            t=row.get('t'),
+            fill_color=parse_color(row.get('fill_color')),
+            stroke_color=parse_color(row.get('stroke_color')),
+            stroke_width=row.get('stroke_width')
+        )
+    return shape
+
+def main(input_file, conn, image_id, log_file):
+    # Open log file
+    with open(log_file, 'w') as log:
+        df = pd.read_csv(input_file, sep='\t')
+        for index, row in df.iterrows():
+            msg = f"Processing row {index + 1}/{len(df)}: {row.to_dict()}"
+            print(msg)
+            log.write(msg + "\n")
+            shape = create_shape(row)
+            if shape:
+                roi_name = row['roi_name'] if 'roi_name' in row else None
+                roi_description = row['roi_description'] if 'roi_description' in row else None
+                roi_id = post_roi(conn, image_id, [shape], name=roi_name, description=roi_description)
+                msg = f"ROI ID: {roi_id} for row {index + 1}"
+                print(msg)
+                log.write(msg + "\n")
+            else:
+                msg = f"Skipping row {index + 1}: Unable to create shape"
+                print(msg)
+                log.write(msg + "\n")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Create shapes from a tabular file and optionally post them as an ROI to OMERO.")
+    parser.add_argument("--input_file", help="Path to the input tabular file.")
+    parser.add_argument("--image_id", type=int, required=True, help="ID of the image to which the ROI will be linked")
+    parser.add_argument("--host", type=str, required=True, help="OMERO server host")
+    parser.add_argument("--user", type=str, required=True, help="OMERO username")
+    parser.add_argument("--psw", type=str, required=True, help="OMERO password")
+    parser.add_argument("--port", type=int, default=4064, help="OMERO server port")
+    parser.add_argument("--log_file", type=str, default="process.txt", help="Log file path")
+
+    args = parser.parse_args()
+
+    conn = connect(
+        host=args.host,
+        user=args.user,
+        password=args.psw,
+        port=args.port,
+        group="",
+        secure=True
+    )
+
+    try:
+        main(args.input_file, conn, args.image_id, args.log_file)
+    finally:
+        conn.close()

--- a/tools/omero/test-data/input_roi.tsv
+++ b/tools/omero/test-data/input_roi.tsv
@@ -1,0 +1,8 @@
+shape	x	y	x_rad	y_rad	label	fontSize	x1	y1	x2	y2	points	width	height	fill_color	stroke_color	stroke_width	z	c	t	roi_name	roi_description
+Ellipse	50.0	50.0	20.0	10.0										(255,0,0,128)	(0,0,0,255)	2	0	0	0	Example ROI	This is an example ROI
+Label	100.0	100.0			Test Label	12.0								(255,255,255,0)	(0,0,255,255)	1	0	0	0	Example ROI	This is an example ROI
+Line							200.0	200.0	250.0	250.0				(0,255,0,128)	(0,0,0,255)	2	0	1	0	Example ROI	This is an example ROI
+Point	150.0	150.0												(0,0,255,128)	(255,0,0,255)	3	0	2	0	Example ROI	This is an example ROI
+Polygon											(300,300),(350,350),(300,400)			(255,255,0,128)	(0,0,0,255)	2	1	0	0	Example ROI	This is an example ROI
+Polyline											(400,400),(450,450),(400,500)			(0,255,255,128)	(0,0,0,255)	3	0	0	0	Example ROI	This is an example ROI
+Rectangle	500.0	500.0										100.0	50.0	(255,0,255,128)	(0,0,0,255)	2	0	0	0	Example ROI	This is an example ROI

--- a/tools/omero/test-data/omero_output.txt
+++ b/tools/omero/test-data/omero_output.txt
@@ -1,2 +1,2 @@
-Image:1
-Image:2
+Image:3
+Image:4

--- a/tools/omero/test-data/output_KV_import.txt
+++ b/tools/omero/test-data/output_KV_import.txt
@@ -1,1 +1,1 @@
-SUCCESS: Successfully uploaded metadata for dataset with ID 1. Result: {'Key1': 'Value1', 'Key2': 'Value2'}
+SUCCESS: Successfully uploaded metadata for dataset with ID 2. Result: {'Key1': 'Value1', 'Key2': 'Value2'}

--- a/tools/omero/test-data/output_table_import.txt
+++ b/tools/omero/test-data/output_table_import.txt
@@ -1,2 +1,2 @@
-SUCCESS: Successfully uploaded metadata for project with ID 1. Result:      Key1    Key2
+SUCCESS: Successfully uploaded metadata for project with ID 2. Result:      Key1    Key2
 0  Value1  Value2

--- a/tools/omero/test-data/output_table_roi.txt
+++ b/tools/omero/test-data/output_table_roi.txt
@@ -1,0 +1,14 @@
+Processing row 1/7: {'shape': 'Ellipse', 'x': 50.0, 'y': 50.0, 'x_rad': 20.0, 'y_rad': 10.0, 'label': nan, 'fontSize': nan, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': nan, 'width': nan, 'height': nan, 'fill_color': '(255,0,0,128)', 'stroke_color': '(0,0,0,255)', 'stroke_width': 2, 'z': 0, 'c': 0, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 1 for row 1
+Processing row 2/7: {'shape': 'Label', 'x': 100.0, 'y': 100.0, 'x_rad': nan, 'y_rad': nan, 'label': 'Test Label', 'fontSize': 12.0, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': nan, 'width': nan, 'height': nan, 'fill_color': '(255,255,255,0)', 'stroke_color': '(0,0,255,255)', 'stroke_width': 1, 'z': 0, 'c': 0, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 2 for row 2
+Processing row 3/7: {'shape': 'Line', 'x': nan, 'y': nan, 'x_rad': nan, 'y_rad': nan, 'label': nan, 'fontSize': nan, 'x1': 200.0, 'y1': 200.0, 'x2': 250.0, 'y2': 250.0, 'points': nan, 'width': nan, 'height': nan, 'fill_color': '(0,255,0,128)', 'stroke_color': '(0,0,0,255)', 'stroke_width': 2, 'z': 0, 'c': 1, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 3 for row 3
+Processing row 4/7: {'shape': 'Point', 'x': 150.0, 'y': 150.0, 'x_rad': nan, 'y_rad': nan, 'label': nan, 'fontSize': nan, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': nan, 'width': nan, 'height': nan, 'fill_color': '(0,0,255,128)', 'stroke_color': '(255,0,0,255)', 'stroke_width': 3, 'z': 0, 'c': 2, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 4 for row 4
+Processing row 5/7: {'shape': 'Polygon', 'x': nan, 'y': nan, 'x_rad': nan, 'y_rad': nan, 'label': nan, 'fontSize': nan, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': '(300,300),(350,350),(300,400)', 'width': nan, 'height': nan, 'fill_color': '(255,255,0,128)', 'stroke_color': '(0,0,0,255)', 'stroke_width': 2, 'z': 1, 'c': 0, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 5 for row 5
+Processing row 6/7: {'shape': 'Polyline', 'x': nan, 'y': nan, 'x_rad': nan, 'y_rad': nan, 'label': nan, 'fontSize': nan, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': '(400,400),(450,450),(400,500)', 'width': nan, 'height': nan, 'fill_color': '(0,255,255,128)', 'stroke_color': '(0,0,0,255)', 'stroke_width': 3, 'z': 0, 'c': 0, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 6 for row 6
+Processing row 7/7: {'shape': 'Rectangle', 'x': 500.0, 'y': 500.0, 'x_rad': nan, 'y_rad': nan, 'label': nan, 'fontSize': nan, 'x1': nan, 'y1': nan, 'x2': nan, 'y2': nan, 'points': nan, 'width': 100.0, 'height': 50.0, 'fill_color': '(255,0,255,128)', 'stroke_color': '(0,0,0,255)', 'stroke_width': 2, 'z': 0, 'c': 0, 't': 0, 'roi_name': 'Example ROI', 'roi_description': 'This is an example ROI'}
+ROI ID: 7 for row 7

--- a/tools/omero/test-data/output_target_import.txt
+++ b/tools/omero/test-data/output_target_import.txt
@@ -1,1 +1,1 @@
-SUCCESS: Successfully uploaded metadata for dataset with ID 1. Result: {'Key1': 'Value1', 'Key2': 'Value2'}
+SUCCESS: Successfully uploaded metadata for dataset with ID 2. Result: {'Key1': 'Value1', 'Key2': 'Value2'}

--- a/tools/omero/test-data/output_target_import.txt
+++ b/tools/omero/test-data/output_target_import.txt
@@ -1,1 +1,1 @@
-SUCCESS: Successfully uploaded metadata for dataset with ID 2. Result: {'Key1': 'Value1', 'Key2': 'Value2'}
+SUCCESS: Successfully uploaded metadata for dataset with ID 1. Result: {'Key1': 'Value1', 'Key2': 'Value2'}


### PR DESCRIPTION
New tool of the OMERO suite to upload region of interests (ROI) in a user-defined OMERO.server using [ezomero](https://github.com/TheJacksonLaboratory/ezomero)

- The tool is taking as input a .tsv file containing information to create a ROI (i.e. Polygon, Ellipse, Points) in OMERO. The ROI will be then associated to a specific image by imputing its ID.

![image](https://github.com/user-attachments/assets/e6c0186f-01c9-4b1e-b2b4-5150231218cd)
![image](https://github.com/user-attachments/assets/a99a968c-766d-4b15-915a-d63b2d6e3638)

- Output is a .txt report with the ROI ID uploaded into OMERO.


**EDIT:** 

This PR fix also the *$__user__.extra_preferences.get* in all xml files:

```
        --user $__user__.extra_preferences.get('omero_account|username', $test_username)
        --psw $__user__.extra_preferences.get('omero_account|password', $test_password)
```