### PR TITLE
Improve help section in the dose-response curve xml tool

### DIFF
--- a/tools/tox_tools/dose_responses/dose_response.xml
+++ b/tools/tox_tools/dose_responses/dose_response.xml
@@ -65,6 +65,18 @@
         - `response_column`: The name of the column in the CSV file that contains the response values
         - `plot_output`: A JPG image file of the dose-response plot.
         - `ec_output`: A tabular file containing the calculated EC values.
+
+        **IMPORTANT**: First column of the input must contain the replicate number. A simple input table might look as the following:
+          +------------+---------------+---------------+
+          | rep        | conc          | resp   |
+          +============+===============+===============+
+          | 1          | 0             | 0             |
+          +------------+---------------+---------------+
+          | 2          | 10            | 50            |
+          +------------+---------------+---------------+
+          | 1          | 5             | 10            |
+          +------------+---------------+---------------+
+        
     ]]></help>
         <citations>
     <citation type="doi">10.1371/journal.pone.0146021</citation>

--- a/tools/tox_tools/dose_responses/dose_response.xml
+++ b/tools/tox_tools/dose_responses/dose_response.xml
@@ -66,7 +66,7 @@
         - `plot_output`: A JPG image file of the dose-response plot.
         - `ec_output`: A tabular file containing the calculated EC values.
 
-        **IMPORTANT**: First column of the input must contain the replicate number. A simple input table might look as the following:
+        **IMPORTANT**: First column of the input table must contain the replicate number (named "rep". Concentration and response should be named "conc" and "resp". A simple input table might look as the following:
           +------------+---------------+---------------+
           | rep        | conc          | resp          |
           +============+===============+===============+

--- a/tools/tox_tools/dose_responses/dose_response.xml
+++ b/tools/tox_tools/dose_responses/dose_response.xml
@@ -68,7 +68,7 @@
 
         **IMPORTANT**: First column of the input must contain the replicate number. A simple input table might look as the following:
           +------------+---------------+---------------+
-          | rep        | conc          | resp   |
+          | rep        | conc          | resp          |
           +============+===============+===============+
           | 1          | 0             | 0             |
           +------------+---------------+---------------+


### PR DESCRIPTION
Correction of the help section in the xml. First column of the tsv input should be the replicate number