### PR TITLE
Tool bug fix: Fixed the KV pair input in the OMERO filter tool

### DIFF
--- a/tools/omero/omero_filter.xml
+++ b/tools/omero/omero_filter.xml
@@ -42,10 +42,8 @@
                 </param>
             </when>
             <when value="KP">
-                <param name="value1" type="text" label="Key Value to search among the image IDs">
-                    <validator type="regex" message="Enter a valid Key to search in the OMERO server">^[\w\-. ]+$</validator>
-                </param>
-                <param name="value2" type="hidden" label="Pair Values to search among images IDs"/>
+                <param name="value1" type="text" label="Key Value to search among the image IDs"/>
+                <param name="value2" type="text" label="Pair Values to search among images IDs"/>
                 <param name="did" type="text" label="List of images IDs">
                     <validator type="regex" message="Enter a valid list of IDs (i.e. 2,45,56,67)">^\d+(,\d+)*$</validator>
                 </param>

--- a/tools/omero/omero_filter.xml
+++ b/tools/omero/omero_filter.xml
@@ -43,10 +43,11 @@
             </when>
             <when value="KP">
                 <param name="value1" type="text" label="Key to search among the image IDs">
-                <validator type="regex" message="Enter a valid Key to search in the OMERO server">^[\w\-. ]+$</validator>
+                    <validator type="regex" message="Enter a valid Key to search in the OMERO server">^[\w\-. ]+$</validator>
                 </param>
                 <param name="value2" type="text" label="Value to search among the image IDs">
-                <validator type="regex" message="Enter a valid Value to search in the OMERO server">^[\w\-. ]+$</validator>
+                    <validator type="regex" message="Enter a valid Value to search in the OMERO server">^[\w\-. ]+$</validator>
+                </param>
                 </param>
                 <param name="did" type="text" label="List of images IDs">
                     <validator type="regex" message="Enter a valid list of IDs (i.e. 2,45,56,67)">^\d+(,\d+)*$</validator>

--- a/tools/omero/omero_filter.xml
+++ b/tools/omero/omero_filter.xml
@@ -48,7 +48,6 @@
                 <param name="value2" type="text" label="Value to search among the image IDs">
                     <validator type="regex" message="Enter a valid Value to search in the OMERO server">^[\w\-. ]+$</validator>
                 </param>
-                </param>
                 <param name="did" type="text" label="List of images IDs">
                     <validator type="regex" message="Enter a valid list of IDs (i.e. 2,45,56,67)">^\d+(,\d+)*$</validator>
                 </param>

--- a/tools/omero/omero_filter.xml
+++ b/tools/omero/omero_filter.xml
@@ -42,8 +42,12 @@
                 </param>
             </when>
             <when value="KP">
-                <param name="value1" type="text" label="Key Value to search among the image IDs"/>
-                <param name="value2" type="text" label="Pair Values to search among images IDs"/>
+                <param name="value1" type="text" label="Key to search among the image IDs">
+                <validator type="regex" message="Enter a valid Key to search in the OMERO server">^[\w\-. ]+$</validator>
+                </param>
+                <param name="value2" type="text" label="Value to search among the image IDs">
+                <validator type="regex" message="Enter a valid Value to search in the OMERO server">^[\w\-. ]+$</validator>
+                </param>
                 <param name="did" type="text" label="List of images IDs">
                     <validator type="regex" message="Enter a valid list of IDs (i.e. 2,45,56,67)">^\d+(,\d+)*$</validator>
                 </param>

--- a/tools/omero/omero_filter.xml
+++ b/tools/omero/omero_filter.xml
@@ -2,7 +2,7 @@
     <description> with ezomero </description>
     <macros>
         <import>macros.xml</import>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <xrefs>
         <xref type="bio.tools">omero</xref>


### PR DESCRIPTION
The OMERO IDs tool did not show the second input value for KP (type was "hidden").
Changed to "text" to allow the user input.